### PR TITLE
Fetch Media in Parallel

### DIFF
--- a/components/player.tsx
+++ b/components/player.tsx
@@ -44,7 +44,7 @@ export const Player = () => {
         <Footer>
           <div>
             <a href="https://github.com/erikreppel/zora.fm">src</a> |{" "}
-            <a href="https://twitter.com/programer">@programmer</a>
+            <a href="https://twitter.com/programmer">@programmer</a>
           </div>
           <div style={{ padding: "3px" }}>
             <themes.ThemeButton

--- a/components/player.tsx
+++ b/components/player.tsx
@@ -12,7 +12,6 @@ import * as themes from "./themes";
 export const Player = () => {
   const mediaPlayer = useMediaPlayer();
   const [theme, setTheme] = useState<themes.theme>(themes.colorWay);
-
   if (mediaPlayer.currentTrack === undefined) {
     return (
       <div>


### PR DESCRIPTION
Previously media was fetch inside a forloop with await, this results in blocking calls

By converting to Promise.All + reduce, we parallelize these requests

No Redis Required